### PR TITLE
fix: incorrect layout when launching sol

### DIFF
--- a/macos/sol-macOS/AppDelegate.swift
+++ b/macos/sol-macOS/AppDelegate.swift
@@ -52,6 +52,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
 
     mainWindow.contentView = visualEffect
     visualEffect.addSubview(rootView)
+        
+    // set constraints in rootview
+    rootView.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint(item: rootView!, attribute: .bottom, relatedBy: .equal, toItem: visualEffect, attribute: .bottom, multiplier: 1, constant: 0).isActive = true
+    NSLayoutConstraint(item: rootView!, attribute: .top, relatedBy: .equal, toItem: visualEffect, attribute: .top, multiplier: 1, constant: 0).isActive = true
+    NSLayoutConstraint(item: rootView!, attribute: .left, relatedBy: .equal, toItem: visualEffect, attribute: .left, multiplier: 1, constant: 0).isActive = true
+    NSLayoutConstraint(item: rootView!, attribute: .right, relatedBy: .equal, toItem: visualEffect, attribute: .right, multiplier: 1, constant: 0).isActive = true
+
     rootView.frame = mainWindow.frame
 
     setupKeyboardListeners()


### PR DESCRIPTION
Fixes a layout issue when first launching sol which was caused by not setting the constraints on `rootView`

**Note**: the initial layout without results doesn't flex to the contents of the original frame, but that's a separate issue not covered in this PR

Before

https://user-images.githubusercontent.com/93789/183042949-c28a3b39-b7a4-439f-b8d9-940cd06edb4e.mp4

After

https://user-images.githubusercontent.com/93789/183042606-36cc7c05-048e-4d78-815f-efde9e5c7ab3.mp4


