### PR TITLE
Trim up arrow emoji

### DIFF
--- a/src/lib/emojis.ts
+++ b/src/lib/emojis.ts
@@ -16704,7 +16704,7 @@ export const emojis = [
     tags: ['right'],
   },
   {
-    emoji: '↑ ',
+    emoji: '↑',
     description: 'up arrow',
     category: 'Apple',
     aliases: [],


### PR DESCRIPTION
I don't know the consequence of this extra space introduced in commit 55db071c72c15d2a46c9527165d420b644957897. 😅