### PR TITLE
Allow accent characters in shortcut

### DIFF
--- a/src/lib/shorcuts.tsx
+++ b/src/lib/shorcuts.tsx
@@ -1,7 +1,7 @@
 import {Key} from 'components/Key'
 
 export const validShortcutTokensRegex =
-  /^(cmd|control|option|command|shift|return|space|right|left|up|down|[a-z]|[0-9])$/
+  /^(cmd|control|option|command|shift|return|space|right|left|up|down|[a-ú]|[0-9])$/
 
 export const defaultShortcuts = {
   // 'option+space': 'sol'


### PR DESCRIPTION
In my french keyboard, the `~` key above the "tab" key is `ù`. I want to bind `cmd+ù` 😄 

I found the regex character in this thread: https://stackoverflow.com/questions/20690499/concrete-javascript-regular-expression-for-accented-characters-diacritics