### PR TITLE
Allow custom search engine as an option

### DIFF
--- a/src/stores/keystroke.store.ts
+++ b/src/stores/keystroke.store.ts
@@ -297,6 +297,19 @@ export const createKeystrokeStore = (root: IRootStore) => {
                       )
                     })
                     break
+                  case 'custom':
+                    Linking.openURL(
+                      root.ui.customSearchUrl.replace(
+                        '%s',
+                        encodeURI(root.ui.query),
+                      ),
+                    ).catch(e => {
+                      solNative.showToast(
+                        `Could not open URL: ${root.ui.query}, error: ${e}`,
+                        'error',
+                      )
+                    })
+                    break
                 }
 
                 solNative.hideWindow()

--- a/src/stores/ui.store.tsx
+++ b/src/stores/ui.store.tsx
@@ -129,7 +129,7 @@ let defaultSearchFolders = [
 ]
 
 export type UIStore = ReturnType<typeof createUIStore>
-type SearchEngine = 'google' | 'bing' | 'duckduckgo' | 'perplexity'
+type SearchEngine = 'google' | 'bing' | 'duckduckgo' | 'perplexity' | 'custom'
 
 const itemsThatShouldShowWindow = [
   'emoji_picker',
@@ -200,6 +200,7 @@ export const createUIStore = (root: IRootStore) => {
           parsedStore.scratchPadColor ?? ScratchPadColor.SYSTEM
         store.searchFolders = parsedStore.searchFolders ?? defaultSearchFolders
         store.searchEngine = parsedStore.searchEngine ?? 'google'
+        store.customSearchUrl = parsedStore.customSearchUrl ?? 'https://google.com/search?q=%s'
         store.shortcuts = parsedStore.shortcuts ?? defaultShortcuts
       })
 
@@ -234,6 +235,7 @@ export const createUIStore = (root: IRootStore) => {
     calendarAuthorizationStatus: null as CalendarAuthorizationStatus | null,
     onboardingStep: 'v1_start' as OnboardingStep,
     searchEngine: 'google' as SearchEngine,
+    customSearchUrl: 'https://google.com/search?q=%s' as string,
     globalShortcut: 'option' as 'command' | 'option' | 'control',
     scratchpadShortcut: 'command' as 'command' | 'option' | 'none',
     clipboardManagerShortcut: 'shift' as 'shift' | 'option' | 'none',
@@ -820,6 +822,10 @@ export const createUIStore = (root: IRootStore) => {
       store.searchEngine = engine
     },
 
+    setCustomSearchUrl: (url: string) => {
+      store.customSearchUrl = url
+    },
+    
     onHotkey({id}: {id: string}) {
       let item = store.items.find(i => i.id === id)
       if (item == null) {

--- a/src/widgets/settings/general.tsx
+++ b/src/widgets/settings/general.tsx
@@ -1,3 +1,4 @@
+import { Input } from 'components/Input'
 import {MyRadioButton} from 'components/MyRadioButton'
 import {MySwitch} from 'components/MySwitch'
 import {solNative} from 'lib/SolNative'
@@ -50,17 +51,38 @@ export const General = observer(() => {
               {label: 'DuckDuckGo', value: 'duckduckgo' as const},
               {label: 'Bing', value: 'bing' as const},
               {label: 'Perplexity', value: 'perplexity' as const},
+              {label: 'Custom', value: 'custom' as const},
             ].map(({label, value}, idx) => {
               return (
-                <MyRadioButton
-                  key={idx}
-                  label={label}
-                  value={value}
-                  onValueChange={() => {
-                    store.ui.setSearchEngine(value)
-                  }}
-                  selected={store.ui.searchEngine === value}
-                />
+                <View className="flex flex-row gap-2 items-start" key={idx}>
+                  <MyRadioButton
+                    label={label}
+                    value={value}
+                    onValueChange={() => {
+                      store.ui.setSearchEngine(value)
+                    }}
+                    selected={store.ui.searchEngine === value}
+                  />
+                  {value === 'custom' && (
+                    <View className="flex-1">
+                      <Input
+                        className="w-80 text-xs rounded border border-lightBorder dark:border-darkBorder px-1"
+                        inputClassName={
+                          store.ui.searchEngine !== 'custom'
+                            ? 'opacity-45 dark:text-white'
+                            : ''
+                        }
+                        readOnly={store.ui.searchEngine !== 'custom'}
+                        value={store.ui.customSearchUrl}
+                        onChangeText={e => store.ui.setCustomSearchUrl(e)}
+                        placeholder="https://google.com/search?q=%s"
+                      />
+                      <Text className="text-xs text-neutral-500 dark:text-neutral-400 mt-1 ml-1">
+                        Use %s in place of the search term
+                      </Text>
+                    </View>
+                  )}
+                </View>
               )
             })}
           </View>


### PR DESCRIPTION
Hi,
I wanted to use brave as search engine , decided to make it generic so any custom search engine should work.
Mostly copied the styling from other parts of the codebase,  feel free to give feedback on what I can improve. 
<img width="690" alt="lightMode" src="https://github.com/user-attachments/assets/41c8ceb2-3fdb-4fc1-aa4e-ab4ba1b7183a" />

<img width="694" alt="darkMode" src="https://github.com/user-attachments/assets/eb023225-17a8-4d2d-a7e0-3b1dbab51732" />
