### PR TITLE
Settings for optionally exclude browser bookmarks from search

### DIFF
--- a/src/widgets/settings/general.tsx
+++ b/src/widgets/settings/general.tsx
@@ -1,4 +1,4 @@
-import { Input } from 'components/Input'
+import {Input} from 'components/Input'
 import {MyRadioButton} from 'components/MyRadioButton'
 import {MySwitch} from 'components/MySwitch'
 import {solNative} from 'lib/SolNative'
@@ -178,6 +178,14 @@ export const General = observer(() => {
           <MySwitch
             value={store.ui.calendarEnabled}
             onValueChange={store.ui.setCalendarEnabled}
+          />
+        </View>
+        <View className="border-t border-lightBorder dark:border-darkBorder" />
+        <View className="flex-row items-center">
+          <Text className="flex-1">Show In-App Browser Bookmarks</Text>
+          <MySwitch
+            value={store.ui.showInAppBrowserBookMarks}
+            onValueChange={store.ui.setShowInAppBrowserBookmarks}
           />
         </View>
         <View className="border-t border-lightBorder dark:border-darkBorder" />


### PR DESCRIPTION
Adds new setting `Show In-App Browser Bookmarks` to optionally exclude bookmarks from search.

In terms of code changes it creates a new observable field `showInAppBrowserBookMarks` in the ui store that is used to track this setting being enabled. The use of `reaction` from mobX is to prevent `minisearch` from having stale data, clear the search index and update when relevant data changes.

In my case, having bookmarks appearing in search felt cluttered. I believe other users will also benefit from it.

Edit: Forgot to say that the bookmarks enabled continues to be the default.
Edit 2: Adds another screenshot for clarity.

Below you're going to find how it looks and simple usage:

<img width="812" alt="sol-bookmarks-1" src="https://github.com/user-attachments/assets/bc35434d-3c62-4e5c-b36e-cc1e44cb07e7" />
<img width="812" alt="sol-bookmarks-2" src="https://github.com/user-attachments/assets/b562db5d-8d90-4531-8e9e-8b569b0c92c7" />
<img width="812" alt="sol-bookmarks-2-5" src="https://github.com/user-attachments/assets/98cbdc74-49dc-4e55-99b6-253831453c61" />
<img width="812" alt="sol-bookmarks-3" src="https://github.com/user-attachments/assets/97639b0e-1db0-4009-917f-d1d5ff16ba1b" />

https://github.com/user-attachments/assets/a2715d6d-84eb-4c76-8253-4896f5e0e5b9