### PR TITLE
Fixes misaligned input in custom shortcut form

### DIFF
--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -54,6 +54,7 @@ export const Input: FC<Props> = ({
         value={props.value}
         onChangeText={props.onChangeText}
         readOnly={props.readOnly}
+        textAlign={props.textAlign}
       />
     </View>
   )

--- a/src/widgets/createItem.widget.tsx
+++ b/src/widgets/createItem.widget.tsx
@@ -105,9 +105,11 @@ export const CreateItemWidget: FC<Props> = observer(({style}) => {
               <Input
                 placeholder="My favorite shortcut..."
                 bordered
-                className="w-64"
+                className={'flex-1'}
+                inputClassName={'w-full'}
                 value={name}
                 onChangeText={setName}
+                textAlign="center"
               />
             </View>
           </View>
@@ -130,10 +132,11 @@ export const CreateItemWidget: FC<Props> = observer(({style}) => {
               bordered
               // broken on 0.71.3
               multiline={isApplescript}
-              className={clsx('flex-1 h-52')}
-              inputClassName={'h-52'}
+              className={'flex-1'}
+              inputClassName={'w-full'}
               value={text}
               onChangeText={setText}
+              textAlign="center"
             />
           </View>
         </View>


### PR DESCRIPTION
Fixes the link/script input in the custom shortcut form being positioned higher than its visible box.

Also makes the actual input full-width so it's easier to click.

Before:
<img width="714" height="462" alt="Screenshot 2025-08-12 at 6 51 41 PM" src="https://github.com/user-attachments/assets/4b16a7cc-cf83-438a-aec6-6ea69d68f5b9" />

After:
<img width="714" height="461" alt="Screenshot 2025-08-12 at 6 50 29 PM" src="https://github.com/user-attachments/assets/d5b9e063-7531-41ab-9c20-17730e3f7dfb" />
