### PR TITLE
Fix: Shortcut List to display correctly considering header

### DIFF
--- a/src/widgets/settings/shortcuts.tsx
+++ b/src/widgets/settings/shortcuts.tsx
@@ -6,6 +6,7 @@ import {renderToKeys} from 'lib/shorcuts'
 import {observer} from 'mobx-react-lite'
 import {
   Image,
+  StyleSheet,
   Text,
   TouchableOpacity,
   TouchableWithoutFeedback,
@@ -91,7 +92,7 @@ export const Shortcuts = observer(() => {
   return (
     <View className="flex-1 h-full p-4">
       <View className="p-3 gap-1 subBg rounded-lg border border-lightBorder dark:border-darkBorder">
-        <View className="flex-row gap-8 p-4">
+        <View className="absolute flex-row w-full pl-6 pr-4 py-6">
           <View className="flex-1">
             <Text className="text">System Wide Shortcuts</Text>
           </View>
@@ -100,6 +101,7 @@ export const Shortcuts = observer(() => {
           </TouchableOpacity>
         </View>
         <LegendList
+          style={STYLES.container}
           contentContainerClassName="px-4 pb-4"
           data={items}
           keyExtractor={item => item.id}
@@ -108,4 +110,10 @@ export const Shortcuts = observer(() => {
       </View>
     </View>
   )
+})
+
+const STYLES = StyleSheet.create({
+  container: {
+    marginTop: 40,
+  },
 })


### PR DESCRIPTION
Current Shortcuts list fails to display the last item. LegendList does not supports a Header components as FlatList does with the props `ListHeaderComponent` or `StickyHeaderComponent` because its items are absolute positioned.

I just made the header positioned absolute and consider its height with `marginTop` in order to display all items correctly.

Before:
<img width="812" height="562" alt="sol-bad-shortcuts" src="https://github.com/user-attachments/assets/731aa923-b122-4114-8f30-3497aee72c42" />

After:
<img width="812" height="562" alt="sol-good-shortcuts" src="https://github.com/user-attachments/assets/eb35efd2-2980-44a8-b3a6-923a147f2167" />
