### PR TITLE
docs: add Symbolic Link Support to features list

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ https://discord.gg/W9XmqCQCKP
 - Blacken Menu Bar
 - Quickly evaluate math operations
 - Script Runner
+- Symbolic Link Support
 
 ## Contributing
 


### PR DESCRIPTION
This introduces a note in the README calling out the new enhancement delivered in issue #195.

Symbolic link support can be particularly useful for third-party package managers that house applications outside of /Applications directories. In my case, I use Nix on macOS to manage a number of applications such as Neovide- but without symbolic link support there wasn't a good way with many launchers to utilize it. With that feature delivered I figured I would add a call-out in the README since that's exactly what I would be looking for- and I'm unlikely to be the only user on the lookout for such a launcher.

Thank you again for implementing that @ospfranco! 🙏