### PR TITLE
Update zh-TW locale icon to Taiwan flag 🇹🇼

### DIFF
--- a/src/lib/languages.ts
+++ b/src/lib/languages.ts
@@ -66,7 +66,7 @@ export const languages = {
   'zh-TW': {
     code: 'zh-TW',
     name: 'Chinese Traditional',
-    flag: '🇨🇳',
+    flag: '🇹🇼',
   },
   co: {
     code: 'co',


### PR DESCRIPTION
In the `languages.ts` file, the icon for the `zh-TW` locale has been updated from the Chinese flag (🇨🇳) to the Taiwan flag (🇹🇼) to better represent Traditional Chinese as used in Taiwan.

https://en.wikipedia.org/wiki/Zh-TW