### PR TITLE
Clipboard: pin items, performance overhaul, UX improvements

### DIFF
--- a/src/stores/clipboard.store.tsx
+++ b/src/stores/clipboard.store.tsx
@@ -6,12 +6,15 @@ import type { IRootStore } from "store";
 import { Widget } from "./ui.store";
 import MiniSearch from "minisearch";
 import { storage } from "./storage";
-import { captureException } from "@sentry/react-native";
+
 
 const MAX_ITEMS = 1000;
+const MAX_TEXT_INDEX_LENGTH = 500; // Only index first N chars for search
+const PERSIST_DEBOUNCE_MS = 2000;
 
 let onTextCopiedListener: EmitterSubscription | undefined;
 let onFileCopiedListener: EmitterSubscription | undefined;
+let persistTimer: ReturnType<typeof setTimeout> | undefined;
 
 export type ClipboardStore = ReturnType<typeof createClipboardStore>;
 
@@ -20,27 +23,118 @@ export type PasteItem = {
 	text: string;
 	url?: string | null;
 	bundle?: string | null;
-	datetime: number; // Unix timestamp when copied
+	datetime: number;
+	pinned?: boolean;
 };
 
+// Simple hash for fast duplicate detection instead of full string comparison
+function hashText(text: string): string {
+	const len = text.length;
+	if (len === 0) return "0";
+	// Use length + first/middle/last chars + a simple rolling hash on a sample
+	const sampleSize = Math.min(len, 256);
+	let h = len;
+	for (let i = 0; i < sampleSize; i++) {
+		const idx = Math.floor((i * len) / sampleSize);
+		h = (Math.imul(h, 31) + text.charCodeAt(idx)) | 0;
+	}
+	return `${len}:${h}`;
+}
+
 const minisearch = new MiniSearch({
-	fields: ["text"],
-	storeFields: ["id", "text", "url", "bundle", "datetime"],
-	// tokenize: (text: string, fieldName?: string) =>
-	// 	text.toLowerCase().split(/[\s\.-]+/),
+	fields: ["indexText"],
+	storeFields: ["id", "datetime"],
 });
 
 export const createClipboardStore = (root: IRootStore) => {
-	const store = makeAutoObservable({
-		deleteItem: (index: number) => {
-			if (index >= 0 && index < store.items.length) {
-				minisearch.remove(store.items[index]);
-				store.items.splice(index, 1);
+	// Hash map for O(1) duplicate detection: hash -> index in items array
+	const textHashMap = new Map<string, number>();
+
+	function rebuildHashMap() {
+		textHashMap.clear();
+		for (let i = 0; i < store.items.length; i++) {
+			const hash = hashText(store.items[i].text);
+			// Only store first occurrence (latest, since items are sorted newest-first)
+			if (!textHashMap.has(hash)) {
+				textHashMap.set(hash, i);
 			}
+		}
+	}
+
+	function findDuplicateIndex(text: string): number {
+		const hash = hashText(text);
+		const candidateIdx = textHashMap.get(hash);
+		if (candidateIdx === undefined || candidateIdx >= store.items.length) {
+			return -1;
+		}
+		// Verify it's actually the same text (hash collision check)
+		if (store.items[candidateIdx].text === text) {
+			return candidateIdx;
+		}
+		return -1;
+	}
+
+	function addToIndex(item: PasteItem) {
+		try {
+			minisearch.add({
+				id: item.id,
+				indexText: item.text.slice(0, MAX_TEXT_INDEX_LENGTH),
+				datetime: item.datetime,
+			});
+		} catch {
+			// ignore duplicate id errors
+		}
+	}
+
+	function removeFromIndex(item: PasteItem) {
+		try {
+			minisearch.discard(item.id);
+		} catch {
+			// ignore missing id errors
+		}
+	}
+
+	const store = makeAutoObservable({
+		clipboardMenuOpen: false,
+		_persistVersion: 0,
+		deleteItem: (displayIndex: number) => {
+			const displayItems = store.clipboardItems;
+			const item = displayItems[displayIndex];
+			if (!item) return;
+			const rawIndex = store.items.findIndex((i) => i.id === item.id);
+			if (rawIndex === -1) return;
+			removeFromIndex(item);
+			store.items.splice(rawIndex, 1);
+			rebuildHashMap();
 		},
 		deleteAllItems: () => {
 			store.items = [];
 			minisearch.removeAll();
+			textHashMap.clear();
+		},
+		toggleClipboardMenu: () => {
+			store.clipboardMenuOpen = !store.clipboardMenuOpen;
+		},
+		closeClipboardMenu: () => {
+			store.clipboardMenuOpen = false;
+		},
+		togglePin: (displayIndex: number) => {
+			const displayItems = store.clipboardItems;
+			const item = displayItems[displayIndex];
+			if (!item) return;
+			const rawIndex = store.items.findIndex((i) => i.id === item.id);
+			if (rawIndex === -1) return;
+			store.items.splice(rawIndex, 1, {
+				...store.items[rawIndex],
+				pinned: !store.items[rawIndex].pinned,
+			});
+			store._persistVersion++;
+			const newIndex = store.clipboardItems.findIndex(
+				(i) => i.id === item.id,
+			);
+			if (newIndex !== -1) {
+				root.ui.selectedIndex = newIndex;
+			}
 		},
 		items: [] as PasteItem[],
 		saveHistory: false,
@@ -55,31 +149,20 @@ export const createClipboardStore = (root: IRootStore) => {
 				...obj,
 			};
 
-			// If save history move file to more permanent storage
-			if (store.saveHistory) {
-				// TODO!
-			}
-
-			// const index = store.items.findIndex(t => t.text === newItem.text)
-			// // Item already exists, move to top
-			// if (index !== -1) {
-			//   // Re-add to minisearch to update the order
-			//   minisearch.remove(store.items[index])
-			//   minisearch.add(newItem)
-
-			//   store.popToTop(index)
-			//   return
-			// }
-
-			// Item does not already exist, put to queue and add to minisearch
 			store.items.unshift(newItem);
-			minisearch.add(newItem);
-
-			// Remove last item from minisearch
+			addToIndex(newItem);
+			rebuildHashMap();
 			store.removeLastItemIfNeeded();
 		},
 		onTextCopied: (obj: { text: string; bundle: string | null }) => {
 			if (!obj.text) {
+				return;
+			}
+
+			const index = findDuplicateIndex(obj.text);
+			// Item already exists, move to top
+			if (index !== -1) {
+				store.popToTop(index);
 				return;
 			}
 
@@ -89,67 +172,85 @@ export const createClipboardStore = (root: IRootStore) => {
 				...obj,
 			};
 
-			const index = store.items.findIndex((t) => t.text === newItem.text);
-			// Item already exists, move to top
-			if (index !== -1) {
-				// Re-add to minisearch to update the order
-				minisearch.remove(store.items[index]);
-				minisearch.add(store.items[index]);
-
-				store.popToTop(index);
-				return;
-			}
-
-			// Item does not already exist, put to queue and add to minisearch
 			store.items.unshift(newItem);
-			minisearch.add(newItem);
-
-			// Remove last item from minisearch
+			addToIndex(newItem);
+			textHashMap.set(hashText(newItem.text), 0);
+			// Shift all existing hash map entries by 1
+			rebuildHashMap();
 			store.removeLastItemIfNeeded();
 		},
 		get clipboardItems(): PasteItem[] {
 			const items = store.items;
 
 			if (!root.ui.query || root.ui.focusedWidget !== Widget.CLIPBOARD) {
-				return items;
+				const hasPinned = items.some((i) => i.pinned);
+				if (!hasPinned) return items.slice();
+				const pinned: PasteItem[] = [];
+				const unpinned: PasteItem[] = [];
+				for (const item of items) {
+					if (item.pinned) pinned.push(item);
+					else unpinned.push(item);
+				}
+				return [...pinned, ...unpinned];
 			}
 
-			// Boost recent items in search results
 			const now = Date.now();
-			return minisearch.search(root.ui.query, {
+			const results = minisearch.search(root.ui.query, {
 				boostDocument: (documentId, term, storedFields) => {
 					const dt =
 						typeof storedFields?.datetime === "number"
 							? storedFields.datetime
 							: Number(storedFields?.datetime);
 					if (!dt || Number.isNaN(dt)) return 1;
-					// Boost items copied in the last 24h, scale down for older
 					const hoursAgo = (now - dt) / (1000 * 60 * 60);
-					if (hoursAgo < 1) return 1.2; // very recent
-					if (hoursAgo < 24) return 1.1; // recent
+					if (hoursAgo < 1) return 1.2;
+					if (hoursAgo < 24) return 1.1;
 					return 1;
 				},
-				// boost: { text: 2 },
-				// prefix: true,
-				// fuzzy: 0.1,
-			}) as any;
+			});
+
+			// Map search results back to full items by id
+			const idToItem = new Map<number, PasteItem>();
+			for (const item of items) {
+				idToItem.set(item.id, item);
+			}
+			const mapped = results
+				.map((r) => idToItem.get(r.id as number))
+				.filter(Boolean) as PasteItem[];
+			const hasPinned = mapped.some((i) => i.pinned);
+			if (!hasPinned) return mapped;
+			const pinned: PasteItem[] = [];
+			const unpinned: PasteItem[] = [];
+			for (const item of mapped) {
+				if (item.pinned) pinned.push(item);
+				else unpinned.push(item);
+			}
+			return [...pinned, ...unpinned];
 		},
 		removeLastItemIfNeeded: () => {
-			if (store.items.length > MAX_ITEMS) {
-				try {
-					minisearch.remove(store.items[store.items.length - 1]);
-				} catch (e) {
-					captureException(e);
+			while (store.items.length > MAX_ITEMS) {
+				// Find the last unpinned item to evict
+				let evictIdx = -1;
+				for (let i = store.items.length - 1; i >= 0; i--) {
+					if (!store.items[i].pinned) {
+						evictIdx = i;
+						break;
+					}
 				}
-
-				store.items = store.items.slice(0, MAX_ITEMS);
+				if (evictIdx === -1) break; // all items are pinned
+				const [removed] = store.items.splice(evictIdx, 1);
+				removeFromIndex(removed);
 			}
 		},
 		popToTop: (index: number) => {
-			const newItems = [...store.items];
-			const item = newItems.splice(index, 1);
-			newItems.unshift(item[0]);
-			store.items = newItems;
+			const [item] = store.items.splice(index, 1);
+			item.datetime = Date.now();
+			store.items.unshift(item);
+			rebuildHashMap();
+			// Update MiniSearch so datetime boost stays correct
+			removeFromIndex(item);
+			addToIndex(item);
+			store._persistVersion++;
 		},
 		setSaveHistory: (v: boolean) => {
 			store.saveHistory = v;
@@ -162,6 +263,10 @@ export const createClipboardStore = (root: IRootStore) => {
 			onTextCopiedListener = undefined;
 			onFileCopiedListener?.remove();
 			onFileCopiedListener = undefined;
+			if (persistTimer) {
+				clearTimeout(persistTimer);
+				persistTimer = undefined;
+			}
 		},
 	});
 
@@ -197,63 +302,66 @@ export const createClipboardStore = (root: IRootStore) => {
 
 			if (entry) {
 				let items = JSON.parse(entry);
-				// Ensure all items have datetime
 				items = items.map((item: any) => ({
 					...item,
 					datetime:
 						typeof item.datetime === "number" && !Number.isNaN(item.datetime)
 							? item.datetime
-							: item.id || Date.now(), // fallback: use id or now
+							: item.id || Date.now(),
 				}));
 				runInAction(() => {
 					store.items = items;
-					minisearch.addAll(store.items);
+					for (const item of store.items) {
+						addToIndex(item);
+					}
+					rebuildHashMap();
 				});
 			}
 		}
 	};
 
-	const persist = async () => {
+	const doPersist = async () => {
 		if (store.saveHistory) {
-			// Ensure all items have datetime before persisting
-			const itemsToPersist = store.items.map((item) => ({
-				...item,
-				datetime:
-					typeof item.datetime === "number" && !Number.isNaN(item.datetime)
-						? item.datetime
-						: item.id || Date.now(),
-			}));
 			try {
 				await solNative.securelyStore(
 					"@sol.clipboard_history_v2",
-					JSON.stringify(itemsToPersist),
+					JSON.stringify(store.items),
 				);
 			} catch (e) {
 				console.warn("Could not persist data", e);
 			}
 		}
 
-		const storeWithoutItems = { ...store };
-		storeWithoutItems.items = [];
-
+		const storeState = { saveHistory: store.saveHistory };
 		try {
 			await AsyncStorage.setItem(
 				"@clipboard.store",
-				JSON.stringify(storeWithoutItems),
+				JSON.stringify(storeState),
 			);
 		} catch (e) {
 			await AsyncStorage.clear();
 			await AsyncStorage.setItem(
 				"@clipboard.store",
-				JSON.stringify(storeWithoutItems),
+				JSON.stringify(storeState),
 			).catch((e) =>
-				console.warn("Could re-persist persist clipboard store", e),
+				console.warn("Could re-persist clipboard store", e),
 			);
 		}
 	};
 
 	hydrate().then(() => {
-		autorun(persist);
+		autorun(() => {
+			// Touch observables to track them
+			const _ = store.items.length;
+			const __ = store.saveHistory;
+			const ___ = store._persistVersion;
+
+			// Debounce the actual persist
+			if (persistTimer) {
+				clearTimeout(persistTimer);
+			}
+			persistTimer = setTimeout(doPersist, PERSIST_DEBOUNCE_MS);
+		});
 	});
 
 	return store;

--- a/src/stores/keystroke.store.ts
+++ b/src/stores/keystroke.store.ts
@@ -30,6 +30,22 @@ export const createKeystrokeStore = (root: IRootStore) => {
 			meta: boolean;
 			shift: boolean;
 		}) => {
+			// Handle clipboard menu when open
+			if (
+				root.clipboard.clipboardMenuOpen &&
+				root.ui.focusedWidget === Widget.CLIPBOARD &&
+				keyCode !== 55 && // let modifier keys pass through
+				keyCode !== 60 &&
+				keyCode !== 59
+			) {
+				// Cmd+P - toggle pin
+				if (keyCode === 35 && meta) {
+					root.clipboard.togglePin(root.ui.selectedIndex);
+				}
+				root.clipboard.closeClipboardMenu();
+				return;
+			}
+
 			switch (keyCode) {
 				// "j" key
 				case 38: {
@@ -41,6 +57,10 @@ export const createKeystrokeStore = (root: IRootStore) => {
 				}
 				// "k" key
 				case 40: {
+					if (meta && root.ui.focusedWidget === Widget.CLIPBOARD) {
+						root.clipboard.toggleClipboardMenu();
+						return;
+					}
 					if (store.controlPressed) {
 						store.keyDown({ keyCode: 126, meta: false, shift: false });
 					}
@@ -62,6 +82,14 @@ export const createKeystrokeStore = (root: IRootStore) => {
 						if (shift) {
 							root.clipboard.deleteItem(root.ui.selectedIndex);
 						}
+						return;
+					}
+					break;
+				}
+				// "p" key
+				case 35: {
+					if (meta && root.ui.focusedWidget === Widget.CLIPBOARD) {
+						root.clipboard.togglePin(root.ui.selectedIndex);
 						return;
 					}
 					break;
@@ -148,13 +176,14 @@ export const createKeystrokeStore = (root: IRootStore) => {
 							const entry =
 								root.clipboard.clipboardItems[root.ui.selectedIndex];
 
-							const originalIndex = root.clipboard.clipboardItems.findIndex(
-								(e) => entry === e,
-							);
-
-							root.clipboard.popToTop(originalIndex);
-
 							if (entry) {
+								const originalIndex = root.clipboard.items.findIndex(
+									(e) => e.id === entry.id,
+								);
+								if (originalIndex !== -1) {
+									root.clipboard.popToTop(originalIndex);
+								}
+
 								if (meta) {
 									try {
 										Linking.openURL(entry.text);
@@ -698,7 +727,7 @@ export const createKeystrokeStore = (root: IRootStore) => {
 						case Widget.CLIPBOARD: {
 							root.ui.selectedIndex = Math.min(
 								root.ui.selectedIndex + 1,
-								root.clipboard.items.length - 1,
+								root.clipboard.clipboardItems.length - 1,
 							);
 							break;
 						}

--- a/src/stores/ui.store.tsx
+++ b/src/stores/ui.store.tsx
@@ -747,6 +747,9 @@ export const createUIStore = (root: IRootStore) => {
 				store.focusWidget(Widget.SEARCH);
 			} else {
 				store.focusWidget(Widget.CLIPBOARD);
+				const items = root.clipboard.clipboardItems;
+				const firstUnpinned = items.findIndex((i) => !i.pinned);
+				store.selectedIndex = firstUnpinned >= 0 ? firstUnpinned : 0;
 			}
 		},
 		showProcessManager: () => {

--- a/src/widgets/clipboard.widget.tsx
+++ b/src/widgets/clipboard.widget.tsx
@@ -7,6 +7,7 @@ import { MainInput } from "components/MainInput";
 import { observer } from "mobx-react-lite";
 import { type FC, useEffect, useRef } from "react";
 import {
+	ScrollView,
 	StyleSheet,
 	Text,
 	TouchableOpacity,
@@ -19,6 +20,14 @@ import type { PasteItem } from "stores/clipboard.store";
 interface Props {
 	style?: ViewStyle;
 	className?: string;
+}
+
+const MAX_PREVIEW_LENGTH = 5000;
+
+function truncateText(text: string | undefined | null): string {
+	if (!text) return "";
+	if (text.length <= MAX_PREVIEW_LENGTH) return text;
+	return text.slice(0, MAX_PREVIEW_LENGTH) + `\n\n... (${text.length.toLocaleString()} chars total)`;
 }
 
 const RenderItem = observer(
@@ -55,9 +64,16 @@ const RenderItem = observer(
 					{item.text.trim()}
 				</Text>
 
-				{/* {!!item.url && (
-        <Image src={`file://${item.url}`} className="h-20 w-20" />
-      )} */}
+				{item.pinned && (
+					<Text
+						className={clsx("text-xs mr-1", {
+							"text-white": isActive,
+							"darker-text": !isActive,
+						})}
+					>
+						{"\u{1F4CC}"}
+					</Text>
+				)}
 			</TouchableOpacity>
 		);
 	},
@@ -99,7 +115,6 @@ export const ClipboardWidget: FC<Props> = observer(() => {
 			<View className="flex-1 flex-row">
 				<View className="w-64 h-full">
 					<LegendList
-						key={`${data.length}`}
 						data={data}
 						className="flex-1"
 						contentContainerStyle={STYLES.contentContainer}
@@ -107,7 +122,7 @@ export const ClipboardWidget: FC<Props> = observer(() => {
 						recycleItems
 						ListEmptyComponent={
 							<View className="flex-1 justify-center items-center">
-								<Text className="darker-text">[ ]</Text>
+								<Text className="darker-text">No items</Text>
 							</View>
 						}
 						renderItem={RenderItem}
@@ -115,22 +130,15 @@ export const ClipboardWidget: FC<Props> = observer(() => {
 				</View>
 				<View className="flex-1 px-3 py-2">
 					{!!data[selectedIndex] && (
-						<View className="dark:bg-black/20 bg-white rounded-lg p-3">
+						<ScrollView
+							className="dark:bg-black/20 bg-white rounded-lg flex-1"
+							contentContainerStyle={{ padding: 12 }}
+						>
 							{!data[selectedIndex].url && (
-								<Text className="text-xs">
-									{data[selectedIndex]?.text ?? []}
+								<Text className="text-xs" selectable>
+									{truncateText(data[selectedIndex]?.text)}
 								</Text>
 							)}
-							{/* {!!data[selectedIndex].url &&
-              isPngOrJpg(data[selectedIndex].url) && (
-                <Image
-                  source={{
-                    uri: `file://${data[selectedIndex].url}`,
-                  }}
-                  className="flex-1 rounded-lg"
-                  style={{resizeMode: 'contain'}}
-                />
-              )} */}
 							{!!data[selectedIndex].url &&
 								!isPngOrJpg(data[selectedIndex].url) && (
 									<View className="flex-1 w-full items-center justify-center">
@@ -143,12 +151,57 @@ export const ClipboardWidget: FC<Props> = observer(() => {
 										</Text>
 									</View>
 								)}
-						</View>
+						</ScrollView>
 					)}
 				</View>
 			</View>
 			{/* Shortcut bar at the bottom */}
 			<View className="py-2 px-4 flex-row items-center justify-end gap-1 subBg border-t border-color">
+				<View style={{ position: "relative" }}>
+					{store.clipboard.clipboardMenuOpen && !!data[selectedIndex] && (
+						<View
+							style={{
+								position: "absolute",
+								bottom: 36,
+								left: 0,
+								zIndex: 10,
+							}}
+						>
+							<View
+								className="rounded-lg p-1 border border-color"
+								style={{
+									minWidth: 200,
+									backgroundColor: store.ui.isDarkMode
+										? "rgba(50,50,50,0.95)"
+										: "rgba(235,235,235,0.95)",
+								}}
+							>
+								<Text className="text-xs darker-text px-3 py-1.5 font-semibold">
+									Actions
+								</Text>
+								<TouchableOpacity
+									onPress={() => {
+										store.clipboard.togglePin(selectedIndex);
+										store.clipboard.closeClipboardMenu();
+									}}
+									className="flex-row items-center gap-2 px-3 py-1.5 rounded"
+								>
+									<Text className="text-sm flex-1">
+										{data[selectedIndex]?.pinned ? "Unpin" : "Pin to top"}
+									</Text>
+									<Key symbol={"⌘"} />
+									<Key symbol="P" />
+								</TouchableOpacity>
+							</View>
+						</View>
+					)}
+					<View className="flex-row items-center gap-1">
+						<Text className="text-xs darker-text mr-1">More</Text>
+						<Key symbol={"⌘"} />
+						<Key symbol={"K"} />
+					</View>
+				</View>
+				<View className="mx-2" />
 				<Text className="text-xs darker-text mr-1">Delete Item</Text>
 				<Key symbol={"⇧"} />
 				<Key symbol={"⌫"} />


### PR DESCRIPTION
## Summary
- **Pinnable clipboard items** (Cmd+P) that always stay at the top, survive reorders, persist across restarts
- **Cmd+K context menu** for clipboard actions, positioned above bottom bar
- **O(1) duplicate detection** via hash map instead of O(n) linear scan
- **MiniSearch indexes only first 500 chars**, maps results back by ID — reduces memory and indexing time
- **In-place array mutations** (splice/unshift) instead of full array copies
- **Debounced persistence** (2s) instead of persisting on every change
- Pinned items **never evicted** when hitting 1000-item limit
- Selection defaults to **first unpinned** (most recently copied) item
- **Shift+Backspace** required to delete, preventing accidental deletion
- Scrollable, selectable detail panel with text truncation at 5,000 chars

## Test plan
- [ ] Open clipboard via hotkey, selection lands on first unpinned item
- [ ] Cmd+K opens context menu, Cmd+P pins/unpins items
- [ ] Pinned items remain at top after copying new text
- [ ] Pin state survives app restart (requires Save History enabled)
- [ ] Shift+Delete deletes correct item even with pinned reordering
- [ ] Search clipboard — results mapped correctly, pinned first
- [ ] Copy large text (100k+) — opens quickly, preview truncated and scrollable
- [ ] Down arrow stops at last visible result