### PR TITLE
Do not dismiss window to prevent RN from resetting it's state

### DIFF
--- a/macos/sol-macOS/managers/PanelManager.swift
+++ b/macos/sol-macOS/managers/PanelManager.swift
@@ -31,13 +31,15 @@ enum PreferredScreen {
     let y = screen.visibleFrame.midY - mainWindow.frame.height + yOffset
     mainWindow.setFrameOrigin(NSPoint(x: floor(x), y: floor(y)))
 
+    mainWindow.setIsVisible(true)
+
     mainWindow.makeKeyAndOrderFront(self)
 
     SolEmitter.sharedInstance.onShow(target: nil)
   }
 
   @objc func hideWindow() {
-    mainWindow.orderOut(self)
+    mainWindow.setIsVisible(false)
     SolEmitter.sharedInstance.onHide()
     HotKeyManager.shared.settingsHotKey.isPaused = true
   }

--- a/src/stores/calendar.store.tsx
+++ b/src/stores/calendar.store.tsx
@@ -144,7 +144,6 @@ export const createCalendarStore = (root: IRootStore) => {
 			onStatusBarItemClickListener?.remove();
 		},
 		onShow: () => {
-			console.log("Fetching events");
 			store.fetchEvents();
 		},
 		getCalendarAccess: () => {


### PR DESCRIPTION
Changes the logic behind dismissing the main window of the app. By not calling .orderOut then we prevent RN from being unmounted and its state being reset. This means a snappier app as when the window opens, there is no longer the overhead of react mounting again