### PR TITLE
Delete local only file ".xcode.env.local" from repo and prevent from re-adding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ DerivedData
 *.ipa
 *.xcuserstate
 ios/.xcode.env.local
+macos/.xcode.env.local
 
 # Windows
 msbuild.binlog

--- a/macos/.xcode.env.local
+++ b/macos/.xcode.env.local
@@ -1,1 +1,0 @@
-export NODE_BINARY=/Users/osp/.local/share/mise/installs/node/22.21.1/bin/node


### PR DESCRIPTION
The .xcode.env.local file exists to allow you to override the behavior of .xcode.env on your system. It is not intended to be checked in to source control.

The file has been deleted and added to .gitignore to prevent it being added again in the future.
