### PR TITLE
fix: use createFromUtf8 instead of createFromAscii in JSI bridge

### DIFF
--- a/macos/sol-macOS/lib/JSIUtils.mm
+++ b/macos/sol-macOS/lib/JSIUtils.mm
@@ -47,7 +47,7 @@ jsi::Value NSDateToJsiValue(jsi::Runtime &rt, NSDate* date) {
 }
 
 jsi::Value NSStringToJsiValue(jsi::Runtime &rt, NSString* v) {
-  auto res = jsi::String::createFromAscii(rt, [v UTF8String]);
+  auto res = jsi::String::createFromUtf8(rt, [v UTF8String]);
   return res;
 }
 


### PR DESCRIPTION
NSStringToJsiValue uses jsi::String::createFromAscii which corrupts non-ASCII characters (Chinese, Japanese, Korean, emoji, etc.). Switching to createFromUtf8 fixes UTF-8 string marshalling across the JSI bridge.