### PR TITLE
Rank direct prefix matches above weaker fuzzy matches

### DIFF
--- a/src/stores/ui.store.tsx
+++ b/src/stores/ui.store.tsx
@@ -160,7 +160,34 @@ export const createUIStore = (root: IRootStore) => {
 		return typeof timestamp === "number" ? timestamp : 0;
 	};
 
+	// ponytail: coarse relevance tier so usage history can only reorder items of
+	// comparable match quality. A fuzzy hit ("Cap" for "cal") never outranks a
+	// direct prefix match ("Calendar") just because it was selected once.
+	const getMatchTier = (item: Pick<Item, "name">) => {
+		const query = store.query.trim().toLowerCase();
+		if (!query) {
+			return 0;
+		}
+
+		const name = item.name.toLowerCase();
+		if (name.startsWith(query)) {
+			return 0;
+		}
+
+		// prefix of any word, e.g. "code" matching "Visual Studio Code"
+		if (name.split(/\s+/).some((word) => word.startsWith(query))) {
+			return 1;
+		}
+
+		return name.includes(query) ? 2 : 3;
+	};
+
 	const compareRankedItems = (left: RankedItem, right: RankedItem) => {
+		const tierDiff = getMatchTier(left) - getMatchTier(right);
+		if (tierDiff !== 0) {
+			return tierDiff;
+		}
+
 		const leftCount = getSelectionCount(left);
 		const rightCount = getSelectionCount(right);
 		const leftWasSelected = leftCount > 0;


### PR DESCRIPTION
Fixes #315

## Problem

`compareRankedItems` compared "has this item ever been selected" *before* the MiniSearch score:

```ts
if (leftWasSelected !== rightWasSelected) {
  return leftWasSelected ? -1 : 1
}
const scoreDiff = (right.score ?? 0) - (left.score ?? 0)
```

Since search runs with `fuzzy: true`, `cal` matches `Cap`. Launching `Cap` once was then enough to put it above `Calendar` and `Calculator` forever — usage history globally overrode relevance instead of breaking ties within it.

## Fix

Add a coarse match tier compared first, so usage only reorders items of comparable relevance:

| tier | match |
|---|---|
| 0 | name starts with the query (`Calendar` for `cal`) |
| 1 | any word in the name starts with it (`Visual Studio Code` for `code`) |
| 2 | name contains it (`Xcode` for `code`) |
| 3 | fuzzy only (`Cap` for `cal`) |

An empty query returns tier 0 for everything, so the no-query list sorted by frequency is unchanged, and #297's usage ranking still applies in full within each tier.

## Verification

Reproduced against `minisearch@7.2.0` with the same search options the store uses, with `Cap` given 3 prior selections:

- `cal` → `Calendar`, `Calculator`, `Cap` (was `Cap`, `Calendar`, `Calculator`)
- `c` with `Calendar` selected → `Calendar` first, usage ranking intact
- empty query → tier flat, ordering untouched

`npm run typecheck` reports the same 5 pre-existing errors on `main` (`Favicon.tsx`, `config.ts`, `emojis.widget.tsx`, `items.tsx`) and none in `ui.store.tsx`. The repo has no test runner, so this check was run as a standalone script rather than committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)