### PR TITLE
Handle ^n/^p like ^j/^k in the search field and guard them from native AppKit handling

### DIFF
--- a/macos/sol-macOS/managers/HotKeyManager.swift
+++ b/macos/sol-macOS/managers/HotKeyManager.swift
@@ -5,6 +5,8 @@ import HotKey
 
 final class HotKeyManager {
   let handledKeys: [UInt16] = [53, 123, 124, 126, 125, 36, 48]
+  // j, k, n, p - used as vim/emacs-style up/down aliases when control is held
+  let controlNavKeys: [UInt16] = [38, 40, 45, 35]
   let numberchars: [String] = ["1", "2", "3", "4", "5", "6", "7", "8", "9"]
   public var catchHorizontalArrowsPress = false
   public var catchVerticalArrowsPress = true
@@ -66,6 +68,13 @@ final class HotKeyManager {
       )
 
       if self.handledKeys.contains($0.keyCode) {
+        return nil
+      }
+
+      // Prevent control+j/k/n/p from falling through to the focused text field,
+      // where AppKit's default emacs-style bindings would move/insert instead
+      // of changing the list selection (handled as up/down aliases in JS).
+      if controlPressed && self.controlNavKeys.contains($0.keyCode) {
         return nil
       }
 

--- a/src/stores/keystroke.store.ts
+++ b/src/stores/keystroke.store.ts
@@ -46,16 +46,17 @@ export const createKeystrokeStore = (root: IRootStore) => {
 			shift: boolean;
 		}) => {
 			switch (keyCode) {
-				// "j" key
-				case 38: {
-					// simulate a down key press
+				// "j" / "n" keys - simulate a down key press
+				case 38:
+				case 45: {
 					if (store.controlPressed) {
 						store.keyDown({ keyCode: 125, meta: false, shift: false });
 					}
 					break;
 				}
-				// "k" key
-				case 40: {
+				// "k" / "p" keys - simulate an up key press
+				case 40:
+				case 35: {
 					if (store.controlPressed) {
 						store.keyDown({ keyCode: 126, meta: false, shift: false });
 					}


### PR DESCRIPTION
Hi @ospfranco, checking to see what you think about the following small changes that I've been running for a while now locally:

Today in Sol, ^j and ^k in the search field will navigate down/up in the list item selection below, which is fine, but these key presses currently also get handled natively by the text box causing an OS chime sound fruitlessly for cases like ^j which attempt to insert a new line on a single line text box. This is an oversight as far as I can tell, so I've added an early out to prevent that for all of the next/previous hotkeys.

I also aliased ^n and ^p as those are the most common/natural next and previous hotkeys natively in macOS and across Vim/Emacs. I left ^j and ^k as-is.