### PR TITLE
Fix Enter handling during IME composition

### DIFF
--- a/macos/sol-macOS/managers/HotKeyManager.swift
+++ b/macos/sol-macOS/managers/HotKeyManager.swift
@@ -51,6 +51,15 @@ final class HotKeyManager {
         return $0
       }
 
+      // Let the input method commit active marked text before treating Enter
+      // as an action on the selected result.
+      if $0.keyCode == 36,
+        let textInputClient = $0.window?.firstResponder as? NSTextInputClient,
+        textInputClient.hasMarkedText()
+      {
+        return $0
+      }
+
       if $0.keyCode == 36 && !self.catchEnterPress {
         return $0
       }


### PR DESCRIPTION
## Problem

When using an input method editor (IME), such as Chinese Pinyin, Japanese, or Korean, pressing Enter while text is still being composed does not commit the marked text to Sol's search field.

Sol's local key event monitor handles key code `36` (Enter), emits it to the JavaScript action handler, and consumes the original event. Because the monitor does not check whether the focused text input has active marked text, the IME never receives Enter.

## Before

1. Open Sol and focus the search field.
2. Use an IME and start composing text.
3. Press Enter to commit the current composition.

The Enter event is consumed by Sol. The composition is not committed, and Sol may execute the currently selected result or close the launcher instead.

## After

When the focused text input has active marked text:

1. The first Enter event is passed through to AppKit and the IME.
2. The IME commits the composition to the search field.
3. A subsequent Enter follows Sol's existing behavior and opens the selected result.

Enter behavior is unchanged when no IME composition is active.

## Fix

Before routing Enter through Sol's action handler, inspect the event window's first responder.

If it conforms to `NSTextInputClient` and `hasMarkedText()` returns `true`, return the original event so the input method can handle it. Otherwise, continue through the existing Sol keyboard handling path.

## Testing

- Swift 5 semantic type-check passed for the modified `HotKeyManager`.
- AppKit regression checks verified that:
  - Enter remains handled by Sol when no marked text exists.
  - Enter passes through while marked text is active.
  - Non-Enter keys are unaffected.
  - Enter returns to Sol after the marked text is committed.
- Full Xcode application build was not run because Xcode is unavailable in the local environment.