### PR TITLE
Allow pasting only part of a clipboard entry

### DIFF
--- a/src/stores/keystroke.store.ts
+++ b/src/stores/keystroke.store.ts
@@ -11,6 +11,9 @@ import { formatTemporaryResultForClipboard } from "./ui.store.helpers";
 let keyDownListener: EmitterSubscription | undefined;
 let keyUpListener: EmitterSubscription | undefined;
 
+const isClipboardPreviewFocused = (root: IRootStore) =>
+	root.ui.focusedWidget === Widget.CLIPBOARD && root.ui.clipboardPreviewFocused;
+
 function isImageClipboardPath(path: string | null | undefined) {
 	if (!path) {
 		return false;
@@ -49,7 +52,7 @@ export const createKeystrokeStore = (root: IRootStore) => {
 				// "j" / "n" keys - simulate a down key press
 				case 38:
 				case 45: {
-					if (store.controlPressed) {
+					if (store.controlPressed && !isClipboardPreviewFocused(root)) {
 						store.keyDown({ keyCode: 125, meta: false, shift: false });
 					}
 					break;
@@ -57,7 +60,7 @@ export const createKeystrokeStore = (root: IRootStore) => {
 				// "k" / "p" keys - simulate an up key press
 				case 40:
 				case 35: {
-					if (store.controlPressed) {
+					if (store.controlPressed && !isClipboardPreviewFocused(root)) {
 						store.keyDown({ keyCode: 126, meta: false, shift: false });
 					}
 					break;
@@ -75,11 +78,31 @@ export const createKeystrokeStore = (root: IRootStore) => {
 					}
 
 					if (root.ui.focusedWidget === Widget.CLIPBOARD) {
-						if (shift) {
+						if (shift && !root.ui.clipboardPreviewFocused) {
 							root.clipboard.deleteItem(root.ui.selectedIndex);
 						}
 						return;
 					}
+					break;
+				}
+				// "c" key
+				case 8: {
+					if (!meta || !isClipboardPreviewFocused(root)) {
+						break;
+					}
+
+					const selectedText = root.ui.clipboardPreviewSelectedText;
+					if (selectedText == null) {
+						break;
+					}
+
+					Clipboard.setString(selectedText);
+					root.ui.setClipboardPreviewFocused(false);
+					solNative.showToast("Copied to clipboard", "success");
+					// The pasteboard watcher would pick the copied fragment up a second
+					// later and unshift it into the history, shifting the selected index
+					// under the user. Closing the window keeps that invisible.
+					solNative.hideWindow();
 					break;
 				}
 				// "e" key
@@ -111,6 +134,11 @@ export const createKeystrokeStore = (root: IRootStore) => {
 						//     break
 						case Widget.SCRATCHPAD:
 							root.ui.rotateScratchPadColor();
+							break;
+
+						case Widget.CLIPBOARD:
+							root.ui.toggleClipboardPreviewFocus();
+							break;
 					}
 
 					break;
@@ -179,7 +207,11 @@ export const createKeystrokeStore = (root: IRootStore) => {
 									}
 									solNative.hideWindow();
 								} else {
-									if (isImageClipboardPath(entry.url)) {
+									const selectedText = root.ui.clipboardPreviewSelectedText;
+									if (selectedText != null) {
+										root.ui.setClipboardPreviewFocused(false);
+										solNative.pasteToFrontmostApp(selectedText);
+									} else if (isImageClipboardPath(entry.url)) {
 										solNative.pasteImageToFrontmostApp(entry.url as string);
 									} else {
 										solNative.pasteToFrontmostApp(entry.text);
@@ -475,6 +507,12 @@ export const createKeystrokeStore = (root: IRootStore) => {
 				case 53: {
 					if (root.ui.confirmDialogShown) {
 						root.ui.closeConfirm();
+						return;
+					}
+
+					// First escape leaves the preview, second one closes the window.
+					if (isClipboardPreviewFocused(root)) {
+						root.ui.setClipboardPreviewFocused(false);
 						return;
 					}
 

--- a/src/stores/ui.store.tsx
+++ b/src/stores/ui.store.tsx
@@ -72,6 +72,17 @@ export enum Widget {
 	FILE_SEARCH = "FILE_SEARCH",
 }
 
+// How much of a pasteboard entry is rendered in the preview pane. The selection
+// indexes reported by the preview are offsets into this prefix, so anything that
+// is not part of the entry itself must be rendered outside of it.
+export const MAX_CLIPBOARD_PREVIEW_LENGTH = 5000;
+
+export type ClipboardPreviewSelection = {
+	start: number;
+	end: number;
+	entryId: number;
+};
+
 export enum ItemType {
 	FILE = "FILE",
 	APPLICATION = "APPLICATION",
@@ -435,6 +446,11 @@ export const createUIStore = (root: IRootStore) => {
 		query: "",
 		selectedIndex: 0,
 		focusedWidget: Widget.SEARCH,
+		clipboardPreviewFocused: false,
+		clipboardPreviewSelection: null as ClipboardPreviewSelection | null,
+		// Bumped only when the preview is focused via the keyboard, so that focusing
+		// it by dragging a selection with the mouse does not reset that selection.
+		clipboardPreviewFocusRequest: 0,
 		events: [] as INativeEvent[],
 		customItems: [] as Item[],
 		disabledItemIds: [] as string[],
@@ -577,6 +593,34 @@ export const createUIStore = (root: IRootStore) => {
 		get currentItem(): Item | undefined {
 			return store.searchItems[store.selectedIndex];
 		},
+		get canFocusClipboardPreview(): boolean {
+			const entry = root.clipboard.clipboardItems[store.selectedIndex];
+			return entry != null && !entry.url && entry.text.length > 0;
+		},
+		get clipboardPreviewSelectedText(): string | null {
+			const selection = store.clipboardPreviewSelection;
+			if (selection == null) {
+				return null;
+			}
+
+			const entry = root.clipboard.clipboardItems[store.selectedIndex];
+			if (entry == null || entry.url || entry.id !== selection.entryId) {
+				return null;
+			}
+
+			const from = Math.max(0, Math.min(selection.start, selection.end));
+			const to = Math.min(
+				entry.text.length,
+				MAX_CLIPBOARD_PREVIEW_LENGTH,
+				Math.max(selection.start, selection.end),
+			);
+
+			if (to <= from) {
+				return null;
+			}
+
+			return entry.text.slice(from, to);
+		},
 		//                _   _
 		//      /\       | | (_)
 		//     /  \   ___| |_ _  ___  _ __  ___
@@ -621,7 +665,42 @@ export const createUIStore = (root: IRootStore) => {
 			store.focusWidget(Widget.SETTINGS);
 		},
 		setSelectedIndex: (idx: number) => {
+			// Clicking a row does not resign the preview's first responder status on
+			// macOS, so the blur handler never runs. Reset here or a stale selection
+			// would be pasted instead of the newly selected entry.
+			store.resetClipboardPreview();
 			store.selectedIndex = idx;
+		},
+		setClipboardPreviewFocused: (focused: boolean) => {
+			if (focused && !store.canFocusClipboardPreview) {
+				return;
+			}
+			store.clipboardPreviewFocused = focused;
+			if (!focused) {
+				store.clipboardPreviewSelection = null;
+			}
+		},
+		toggleClipboardPreviewFocus: () => {
+			if (store.clipboardPreviewFocused) {
+				store.setClipboardPreviewFocused(false);
+				return;
+			}
+
+			if (!store.canFocusClipboardPreview) {
+				return;
+			}
+
+			store.clipboardPreviewFocused = true;
+			store.clipboardPreviewFocusRequest += 1;
+		},
+		setClipboardPreviewSelection: (
+			selection: ClipboardPreviewSelection | null,
+		) => {
+			store.clipboardPreviewSelection = selection;
+		},
+		resetClipboardPreview: () => {
+			store.clipboardPreviewFocused = false;
+			store.clipboardPreviewSelection = null;
 		},
 		setNote: (note: string) => {
 			store.note = note;
@@ -714,6 +793,7 @@ export const createUIStore = (root: IRootStore) => {
 			store.showWindowOn = on;
 		},
 		focusWidget: (widget: Widget) => {
+			store.resetClipboardPreview();
 			store.selectedIndex = 0;
 			store.focusedWidget = widget;
 		},
@@ -895,6 +975,7 @@ export const createUIStore = (root: IRootStore) => {
 			store.isVisible = false;
 			store.focusedWidget = Widget.SEARCH;
 			store.editingCustomItem = null;
+			store.resetClipboardPreview();
 			if (store.temporaryResult == null) {
 				store.setQuery("");
 			}

--- a/src/widgets/clipboard.widget.tsx
+++ b/src/widgets/clipboard.widget.tsx
@@ -4,6 +4,7 @@ import { FileIcon } from "components/FileIcon";
 import { Key } from "components/Key";
 import { LoadingBar } from "components/LoadingBar";
 import { MainInput } from "components/MainInput";
+import { solNative } from "lib/SolNative";
 import { observer } from "mobx-react-lite";
 import { type FC, useEffect, useRef } from "react";
 import {
@@ -15,21 +16,18 @@ import {
 	View,
 	type ViewStyle,
 } from "react-native";
+import { TextInput } from "react-native-macos";
 import { useStore } from "store";
 import type { PasteItem } from "stores/clipboard.store";
+import { MAX_CLIPBOARD_PREVIEW_LENGTH } from "stores/ui.store";
 
 interface Props {
 	style?: ViewStyle;
 	className?: string;
 }
 
-const MAX_PREVIEW_LENGTH = 5000;
-
-function truncateText(text: string | undefined | null): string {
-	if (!text) return "";
-	if (text.length <= MAX_PREVIEW_LENGTH) return text;
-	return `${text.slice(0, MAX_PREVIEW_LENGTH)}\n\n... (${text.length.toLocaleString()} chars total)`;
-}
+// Swallowed by the text view so the Edit menu does not copy on top of us.
+const COPY_KEY_EVENTS = [{ key: "c", metaKey: true }];
 
 function isImageUrl(url: string | null | undefined) {
 	if (!url) {
@@ -100,6 +98,14 @@ export const ClipboardWidget: FC<Props> = observer(() => {
 	const data = store.clipboard.clipboardItems;
 	const selectedIndex = store.ui.selectedIndex;
 	const listRef = useRef<LegendListRef | null>(null);
+	const previewRef = useRef<TextInput | null>(null);
+	const previouslyFocusedRef = useRef<ReturnType<
+		typeof TextInput.State.currentlyFocusedInput
+	> | null>(null);
+	const entry = data[selectedIndex];
+	const previewFocused = store.ui.clipboardPreviewFocused;
+	const focusRequest = store.ui.clipboardPreviewFocusRequest;
+	const hasSelection = store.ui.clipboardPreviewSelectedText != null;
 
 	useEffect(() => {
 		if (data.length > 0 && selectedIndex < data.length) {
@@ -109,6 +115,47 @@ export const ClipboardWidget: FC<Props> = observer(() => {
 			});
 		}
 	}, [selectedIndex, data.length, store.ui.selectedIndex]);
+
+	// While the preview is not focused the search input holds the focus. Remember
+	// it so it can be handed back, no matter how the preview got focused.
+	useEffect(() => {
+		if (previewFocused) {
+			return;
+		}
+		const focused = TextInput.State.currentlyFocusedInput();
+		if (focused != null) {
+			previouslyFocusedRef.current = focused;
+		}
+	});
+
+	useEffect(() => {
+		if (focusRequest === 0) {
+			return;
+		}
+		previewRef.current?.focus();
+		// Gives shift + arrow keys an anchor to extend from.
+		previewRef.current?.setSelection(0, 0);
+	}, [focusRequest]);
+
+	useEffect(() => {
+		if (!previewFocused && previouslyFocusedRef.current != null) {
+			TextInput.State.focusTextInput(previouslyFocusedRef.current);
+		}
+	}, [previewFocused]);
+
+	useEffect(() => {
+		// Arrow keys are swallowed natively to drive the list, which would leave the
+		// preview unable to extend a selection vertically.
+		if (previewFocused) {
+			solNative.turnOffVerticalArrowsListeners();
+		} else {
+			solNative.turnOnVerticalArrowsListeners();
+		}
+
+		return () => {
+			solNative.turnOnVerticalArrowsListeners();
+		};
+	}, [previewFocused]);
 
 	return (
 		<View className="flex-1">
@@ -134,54 +181,100 @@ export const ClipboardWidget: FC<Props> = observer(() => {
 					/>
 				</View>
 				<View className="flex-1 px-3 py-2">
-					{!!data[selectedIndex] && (
-						<ScrollView
-							className="dark:bg-black/20 bg-white rounded-lg flex-1"
-							contentContainerStyle={{ padding: 12 }}
+					{!!entry && !entry.url && (
+						<View
+							className={clsx(
+								"dark:bg-black/20 bg-white rounded-lg flex-1 p-3 border",
+								previewFocused ? "border-accent" : "border-transparent",
+							)}
 						>
-							{!data[selectedIndex].url && (
-								<Text className="text-xs">
-									{truncateText(data[selectedIndex]?.text)}
+							<TextInput
+								ref={previewRef}
+								multiline
+								editable={false}
+								enableFocusRing={false}
+								keyDownEvents={COPY_KEY_EVENTS}
+								value={entry.text.slice(0, MAX_CLIPBOARD_PREVIEW_LENGTH)}
+								onFocus={() => store.ui.setClipboardPreviewFocused(true)}
+								onBlur={() => store.ui.setClipboardPreviewFocused(false)}
+								onSelectionChange={(e) => {
+									const { start, end } = e.nativeEvent.selection;
+									store.ui.setClipboardPreviewSelection(
+										start === end ? null : { start, end, entryId: entry.id },
+									);
+								}}
+								className="text-xs flex-1"
+							/>
+							{entry.text.length > MAX_CLIPBOARD_PREVIEW_LENGTH && (
+								<Text className="text-xs darker-text mt-2">
+									{`Preview truncated — ${entry.text.length.toLocaleString()} chars total`}
 								</Text>
 							)}
+						</View>
+					)}
 
-							{!!data[selectedIndex].url &&
-								isImageUrl(data[selectedIndex].url) && (
-									<View className="flex-1 items-center justify-center">
-										<Image
-											source={{
-												uri: toFileUri(data[selectedIndex].url as string),
-											}}
-											style={{ width: "100%", height: 360 }}
-											resizeMode="contain"
-										/>
-									</View>
-								)}
-
-							{!!data[selectedIndex].url &&
-								!isImageUrl(data[selectedIndex].url) && (
-									<View className="flex-1 w-full items-center justify-center">
-										<FileIcon
-											url={`file://${data[selectedIndex].url}`}
-											className="h-20 w-20"
-										/>
-										<Text className="font-mono">
-											{data[selectedIndex].text}
-										</Text>
-									</View>
-								)}
+					{!!entry?.url && (
+						<ScrollView
+							className="dark:bg-black/20 bg-white rounded-lg flex-1"
+							contentContainerStyle={STYLES.previewContainer}
+						>
+							{isImageUrl(entry.url) ? (
+								<View className="flex-1 items-center justify-center">
+									<Image
+										source={{ uri: toFileUri(entry.url as string) }}
+										style={STYLES.previewImage}
+										resizeMode="contain"
+									/>
+								</View>
+							) : (
+								<View className="flex-1 w-full items-center justify-center">
+									<FileIcon url={`file://${entry.url}`} className="h-20 w-20" />
+									<Text className="font-mono">{entry.text}</Text>
+								</View>
+							)}
 						</ScrollView>
 					)}
 				</View>
 			</View>
 			{/* Shortcut bar at the bottom */}
 			<View className="py-2 px-4 flex-row items-center justify-end gap-1 subBg border-t border-color">
-				<Text className="text-xs darker-text mr-1">Delete Item</Text>
-				<Key symbol={"⇧"} />
-				<Key symbol={"⌫"} />
-				<View className="mx-2" />
-				<Text className={"text-xs mr-1"}>Paste</Text>
-				<Key symbol={"⏎"} primary />
+				{previewFocused ? (
+					<>
+						<Text className="text-xs darker-text mr-1">Back to List</Text>
+						<Key symbol={"⇥"} />
+						{hasSelection && (
+							<>
+								<View className="mx-2" />
+								<Text className="text-xs darker-text mr-1">Copy</Text>
+								<Key symbol={"⌘"} />
+								<Key symbol={"C"} />
+							</>
+						)}
+						<View className="mx-2" />
+						<Text className={"text-xs mr-1"}>
+							{hasSelection ? "Paste Selection" : "Paste"}
+						</Text>
+						<Key symbol={"⏎"} primary />
+					</>
+				) : (
+					<>
+						{store.ui.canFocusClipboardPreview && (
+							<>
+								<Text className="text-xs darker-text mr-1">
+									Select in Preview
+								</Text>
+								<Key symbol={"⇥"} />
+								<View className="mx-2" />
+							</>
+						)}
+						<Text className="text-xs darker-text mr-1">Delete Item</Text>
+						<Key symbol={"⇧"} />
+						<Key symbol={"⌫"} />
+						<View className="mx-2" />
+						<Text className={"text-xs mr-1"}>Paste</Text>
+						<Key symbol={"⏎"} primary />
+					</>
+				)}
 			</View>
 		</View>
 	);
@@ -192,5 +285,12 @@ const STYLES = StyleSheet.create({
 		flexGrow: 1,
 		paddingVertical: 6,
 		paddingLeft: 8,
+	},
+	previewContainer: {
+		padding: 12,
+	},
+	previewImage: {
+		width: "100%",
+		height: 360,
 	},
 });


### PR DESCRIPTION
### What

Picking an entry from the clipboard manager always pastes the whole thing. When I copy a long block — a log line, a list of URLs, a chunk of code — I can't grab a single piece of it from Sol; I have to paste everything somewhere else and trim it by hand.

This makes the preview pane selectable, so a fragment can be pasted or copied directly.

### How it works

- **Tab** moves focus between the list and the preview
- Select with the mouse or **shift + arrows**
- **Enter** pastes only the selection, **⌘C** copies it to the pasteboard
- With nothing selected, everything behaves exactly as before

The shortcut bar at the bottom reflects the current mode.

### Implementation notes

The preview is now a read-only multiline `TextInput` rather than a plain `Text`. I first tried `<Text selectable>`, but on macOS its inner `NSTextView` is `canBecomeKeyView = NO`, never reports the selection back to JS, and its `copy:` puts the *entire* text on the pasteboard as RTFD only — so none of the above would have worked.

Three details that are easy to miss:

- Vertical arrow listeners are turned off while the preview has focus. Otherwise the arrows are swallowed natively to drive the list and a selection can never be extended downwards. They are turned back on when focus leaves *and* on unmount, so hiding the window mid-selection can't leave the rest of the app without arrow keys.
- The "truncated" hint moved outside the input, so selection indexes stay aligned with the entry text.
- ⌘C hides the window. The pasteboard watcher polls once a second and would otherwise pick the copied fragment back up as a new entry, shifting the selected index under the cursor.

No native changes were needed — `pasteToFrontmostApp` already takes an arbitrary string.

### Testing

Tested manually: keyboard and mouse selection, paste and copy, escape/tab focus round-trips, image and file entries (the preview isn't focusable for those), and entries longer than the 5000 char preview limit. `bun typecheck` reports the same four pre-existing errors as on `main`, nothing new.