### PR TITLE
Item list on empty query

### DIFF
--- a/src/components/PermissionsBar.tsx
+++ b/src/components/PermissionsBar.tsx
@@ -8,7 +8,7 @@ import { Key } from "./Key";
 export const PermissionsBar: FC = observer(() => {
 	const store = useStore();
 
-	if (store.ui.query) {
+	if (store.ui.itemListVisible) {
 		return null;
 	}
 

--- a/src/containers/root.container.tsx
+++ b/src/containers/root.container.tsx
@@ -24,12 +24,12 @@ export const RootContainer = observer(() => {
     <View
       className={clsx('dark:bg-gray-900/10', {
         fullWindow:
-          !!store.ui.query ||
+          store.ui.itemListVisible ||
           (store.ui.calendarEnabled && store.calendar.events.length > 0),
       })}>
       <SearchWidget />
 
-      {!store.ui.query && store.ui.calendarEnabled && <FullCalendar />}
+      {!store.ui.itemListVisible && store.ui.calendarEnabled && <FullCalendar />}
 
       <PermissionsBar />
     </View>

--- a/src/stores/config.ts
+++ b/src/stores/config.ts
@@ -20,6 +20,7 @@ export const PORTABLE_KEYS = [
 	"customSearchUrl",
 	"shortcuts",
 	"showInAppBrowserBookMarks",
+	"showItemsOnEmptyQuery",
 	"hasDismissedGettingStarted",
 	"hyperKeyEnabled",
 	"customItems",

--- a/src/stores/keystroke.store.ts
+++ b/src/stores/keystroke.store.ts
@@ -259,7 +259,7 @@ export const createKeystrokeStore = (root: IRootStore) => {
 
 						case Widget.SEARCH: {
 							if (
-								!root.ui.query &&
+								!root.ui.itemListVisible &&
 								root.ui.calendarAuthorizationStatus === "notDetermined"
 							) {
 								solNative
@@ -274,13 +274,13 @@ export const createKeystrokeStore = (root: IRootStore) => {
 								return;
 							}
 
-							if (!root.ui.query && !root.ui.isAccessibilityTrusted) {
+							if (!root.ui.itemListVisible && !root.ui.isAccessibilityTrusted) {
 								solNative.requestAccessibilityAccess();
 								solNative.hideWindow();
 								return;
 							}
 
-							if (!root.ui.query) {
+							if (!root.ui.itemListVisible) {
 								if (!root.ui.hasDismissedGettingStarted) {
 									Linking.openURL(
 										"https://sol.ospfranco.com/getting_started",
@@ -320,13 +320,13 @@ export const createKeystrokeStore = (root: IRootStore) => {
 
 							root.ui.addToHistory(root.ui.query);
 
-							if (shift) {
+							if (shift && root.ui.query) {
 								root.ui.translateQuery();
 								return;
 							}
 
 							// If there are no visible items, or if the query is a meta (⌘ is pressed) query, open a browser search
-							if (!root.ui.searchItems.length || meta) {
+							if (root.ui.query && (!root.ui.searchItems.length || meta)) {
 								switch (root.ui.searchEngine) {
 									case "google":
 										Linking.openURL(
@@ -754,7 +754,7 @@ export const createKeystrokeStore = (root: IRootStore) => {
 
 						case Widget.SEARCH: {
 							root.ui.selectedIndex = Math.min(
-								root.ui.items.length - 1,
+								root.ui.searchItems.length - 1,
 								root.ui.selectedIndex + 1,
 							);
 							break;

--- a/src/stores/ui.store.tsx
+++ b/src/stores/ui.store.tsx
@@ -303,6 +303,7 @@ export const createUIStore = (root: IRootStore) => {
 					store.shortcuts = applyShortcutNormalization(src.shortcuts);
 					store.showInAppBrowserBookMarks =
 						src.showInAppBrowserBookMarks ?? true;
+					store.showItemsOnEmptyQuery = src.showItemsOnEmptyQuery ?? false;
 					store.hasDismissedGettingStarted =
 						src.hasDismissedGettingStarted ?? false;
 					store.hyperKeyEnabled = src.hyperKeyEnabled ?? false;
@@ -391,6 +392,8 @@ export const createUIStore = (root: IRootStore) => {
 				if (jsonConfig.showInAppBrowserBookMarks !== undefined)
 					store.showInAppBrowserBookMarks =
 						jsonConfig.showInAppBrowserBookMarks;
+				if (jsonConfig.showItemsOnEmptyQuery !== undefined)
+					store.showItemsOnEmptyQuery = jsonConfig.showItemsOnEmptyQuery;
 				if (jsonConfig.hyperKeyEnabled !== undefined)
 					store.hyperKeyEnabled = jsonConfig.hyperKeyEnabled;
 				if (jsonConfig.customItems !== undefined)
@@ -465,6 +468,7 @@ export const createUIStore = (root: IRootStore) => {
 		searchFolders: [] as string[],
 		shortcuts: defaultShortcuts as Record<string, string>,
 		showInAppBrowserBookMarks: true,
+		showItemsOnEmptyQuery: false,
 		hoveredEventId: null as string | null,
 		hasDismissedGettingStarted: false,
 		isVisible: false,
@@ -571,8 +575,24 @@ export const createUIStore = (root: IRootStore) => {
 
 			return finalResults;
 		},
+		get itemListVisible(): boolean {
+			// The permission and getting started prompts keep Enter to themselves until onboarding is done
+			return (
+				!!store.query ||
+				(store.showItemsOnEmptyQuery &&
+					store.searchItems.length > 0 &&
+					store.calendarAuthorizationStatus != null &&
+					store.calendarAuthorizationStatus !== "notDetermined" &&
+					store.hasDismissedGettingStarted)
+			);
+		},
 		get searchItems(): Item[] {
-			return store.items.filter((item) => !store.isItemDisabled(item.id));
+			// Bookmarks stay search-only, their favicons fire network fetches
+			return store.items.filter(
+				(item) =>
+					!store.isItemDisabled(item.id) &&
+					(!!store.query || item.type !== ItemType.BOOKMARK),
+			);
 		},
 		get currentItem(): Item | undefined {
 			return store.searchItems[store.selectedIndex];
@@ -602,6 +622,9 @@ export const createUIStore = (root: IRootStore) => {
 		setShowUpcomingEvent: (v: boolean) => {
 			store.showUpcomingEvent = v;
 			solNative.setUpcomingEventEnabled(v && store.calendarEnabled);
+		},
+		setShowItemsOnEmptyQuery: (v: boolean) => {
+			store.showItemsOnEmptyQuery = v;
 		},
 		recordItemSelection: (item: Item) => {
 			const previousCount = getSelectionCount(item);
@@ -1090,6 +1113,9 @@ export const createUIStore = (root: IRootStore) => {
 		},
 
 		addToHistory: (query: string) => {
+			if (!query) {
+				return;
+			}
 			store.history.push(query);
 		},
 

--- a/src/widgets/search.widget.tsx
+++ b/src/widgets/search.widget.tsx
@@ -285,14 +285,14 @@ export const SearchWidget: FC = observer(() => {
 	return (
 		<View
 			className={clsx({
-				"flex-1": !!store.ui.query,
+				"flex-1": store.ui.itemListVisible,
 			})}
 		>
 			<View className="flex-row items-center gap-2 px-3">
 				<MainInput className="flex-1" hideIcon />
 			</View>
 
-			{!!store.ui.query && (
+			{store.ui.itemListVisible && (
 				<>
 					<LoadingBar />
 					<LegendList
@@ -321,33 +321,37 @@ export const SearchWidget: FC = observer(() => {
 								<View className="mx-2" />
 							</>
 						)}
-						<Text className="text-xs darker-text mr-1">Translate</Text>
-						<Key symbol={"⇧"} />
-						<Key symbol={"⏎"} />
-						{!items.length && (
+						{!!store.ui.query && (
 							<>
+								<Text className="text-xs darker-text mr-1">Translate</Text>
+								<Key symbol={"⇧"} />
+								<Key symbol={"⏎"} />
+								{!items.length && (
+									<>
+										<View className="mx-2" />
+										<Text
+											className={clsx("text-xs darker-text mr-1", {
+												"font-semibold": !items.length,
+											})}
+										>
+											Search
+										</Text>
+										<Key symbol={"⌘"} />
+										<Key symbol={"⏎"} />
+									</>
+								)}
 								<View className="mx-2" />
 								<Text
 									className={clsx("text-xs darker-text mr-1", {
 										"font-semibold": !items.length,
 									})}
 								>
-									Search
+									Browser Search
 								</Text>
-								<Key symbol={"⌘"} />
-								<Key symbol={"⏎"} />
+								{!!items.length && <Key symbol={"⌘"} />}
+								<Key symbol={"⏎"} primary={!items.length} />
 							</>
 						)}
-						<View className="mx-2" />
-						<Text
-							className={clsx("text-xs darker-text mr-1", {
-								"font-semibold": !items.length,
-							})}
-						>
-							Browser Search
-						</Text>
-						{!!items.length && <Key symbol={"⌘"} />}
-						<Key symbol={"⏎"} primary={!items.length} />
 						{!!items.length && (
 							<>
 								<View className="mx-2" />

--- a/src/widgets/settings/general.tsx
+++ b/src/widgets/settings/general.tsx
@@ -193,6 +193,14 @@ export const General = observer(() => {
 				</View>
 				<View className="border-t border-lightBorder dark:border-darkBorder" />
 				<View className="flex-row items-center">
+					<Text className="flex-1">Show items when search is empty</Text>
+					<MySwitch
+						value={store.ui.showItemsOnEmptyQuery}
+						onValueChange={store.ui.setShowItemsOnEmptyQuery}
+					/>
+				</View>
+				<View className="border-t border-lightBorder dark:border-darkBorder" />
+				<View className="flex-row items-center">
 					<Text className="flex-1">Show upcoming event in Menu Bar</Text>
 					<MySwitch
 						value={store.ui.showUpcomingEvent}


### PR DESCRIPTION
Adds an opt-in setting (General > "Show items when search is empty") that shows the frecency ranked item list as soon as the window opens, before anything is typed, so the most used apps are one keystroke away. The setting is off by default and with it off every touched code path evaluates exactly as it does today.

Behavior with the setting on:

- On an empty query the search widget lists apps, base commands, custom items and scripts sorted by the existing `compareRankedItems` ranking
- Bookmarks stay search only, since every visible bookmark row fires a favicon network fetch
- The calendar permission, accessibility and getting started prompts keep Enter to themselves until onboarding is done, then the list takes over
- While the list is visible it replaces the calendar pane and the Enter to join meeting shortcut, and the footer plus PermissionsBar hints always match what Enter actually does

Implementation notes:

- A new `itemListVisible` computed on the UI store is the single predicate shared by the search widget, window sizing, FullCalendar and the Enter handler
- `showItemsOnEmptyQuery` persists through `PORTABLE_KEYS` like its sibling settings
- Down arrow now clamps to `searchItems.length` instead of `items.length`; with disabled items the selection could previously run past the rendered list
- Guards on Enter keep empty queries out of the search history, translation and browser search paths
