### PR TITLE
Fix localized application search normalization

### DIFF
--- a/src/stores/ui.store.tsx
+++ b/src/stores/ui.store.tsx
@@ -114,7 +114,11 @@ const minisearch = new MiniSearch({
 		"bookmarkFolder",
 		"faviconFallback",
 	],
-	tokenize: (text: string) => text.toLowerCase().split(/[\s.-]+/),
+	tokenize: (text: string) =>
+		text
+			.normalize("NFC")
+			.toLowerCase()
+			.split(/[\s.-]+/),
 });
 
 const userName = solNative.userName();


### PR DESCRIPTION
macOS can return localized app names in NFD, while search input can be NFC. For example, the built-in Calendar app may not appear when searching for its Korean name, `캘린더`. The same issue can affect other localized app names.

Normalize MiniSearch tokens to NFC before indexing and searching. Existing NFC searches, token separators, and search options are unchanged.

Tested with NFC/NFD Korean names, Korean prefix searches, and English app names.