### PR TITLE
Accept decimal commas in calculator queries

### DIFF
--- a/src/stores/ui.store.helpers.ts
+++ b/src/stores/ui.store.helpers.ts
@@ -487,12 +487,28 @@ export function formatTemporaryResultForClipboard(result: TemporaryResult) {
 	return details ? `${result.flight} | ${details}` : result.flight;
 }
 
-export function formatExpressionResult(value: number) {
+export function normalizeCalculatorQuery(query: string): string {
+	return query
+		.replace(
+			/(\d{1,3}(?:\.\d{3})+),(\d+)/g,
+			(_, whole: string, fraction: string) =>
+				`${whole.replace(/\./g, "")}.${fraction}`,
+		)
+		.replace(/(\d),(\d)/g, "$1.$2");
+}
+
+export function formatExpressionResult(value: number, query = "") {
 	if (!Number.isFinite(value)) {
 		return value.toString();
 	}
 
 	const scale = 10 ** EXPRESSION_RESULT_DECIMALS;
 	const rounded = Math.round((value + Number.EPSILON) * scale) / scale;
-	return rounded.toString();
+	const text = rounded.toString();
+
+	if (/\d,\d/.test(query)) {
+		return text.replace(".", ",");
+	}
+
+	return text;
 }

--- a/src/stores/ui.store.tsx
+++ b/src/stores/ui.store.tsx
@@ -39,6 +39,7 @@ import {
 	formatExpressionResult,
 	type BookmarkNode,
 	getInitials,
+	normalizeCalculatorQuery,
 	parseFlightIdentifier,
 	parseTimezoneConversion,
 	parseUnitConversion,
@@ -770,10 +771,12 @@ export const createUIStore = (root: IRootStore) => {
 				}
 
 				try {
-					const res = exprParser.evaluate(store.query);
+					const res = exprParser.evaluate(
+						normalizeCalculatorQuery(store.query),
+					);
 					if (typeof res === "number" && !Number.isNaN(res)) {
 						store.temporaryResult = createTextTemporaryResult(
-							formatExpressionResult(res),
+							formatExpressionResult(res, store.query),
 							store.query,
 						);
 					} else {


### PR DESCRIPTION
The calculator uses expr-eval, which only parses dotted decimals, so queries like `123,45 + 543,21` never evaluated.

This normalizes numbers format common in Europe (including `1.234,56`) before evaluation, and formats the result with a comma when the query used one. Dotted input like `1.5 + 2.5` is unchanged.